### PR TITLE
Loopy refresh fix

### DIFF
--- a/server/js/player.js
+++ b/server/js/player.js
@@ -226,7 +226,18 @@ module.exports = Player = Character.extend({
                         
                         if(kind === Types.Entities.FIREPOTION) {
                             self.updateHitPoints();
-                            self.broadcast(self.equip(Types.Entities.FIREFOX));
+
+                            if (self.firepotionTimeout != null) {
+                                /* Issue #195: If the player is already a firefox when picking a firepotion
+                                Then cancel the queued "return to normal"
+                                New timeout will start and refresh the duration */
+                                clearTimeout(self.firepotionTimeout);
+                                self.firepotionTimeout = null;
+                            }
+                            else {
+                                self.broadcast(self.equip(Types.Entities.FIREFOX));
+                            }
+
                             self.firepotionTimeout = setTimeout(function() {
                                 self.broadcast(self.equip(self.armor)); // return to normal
                                 self.firepotionTimeout = null;


### PR DESCRIPTION
Fixed a LoopyPower refresh bug, explained in details in https://github.com/balkshamster/looperlands/issues/195.
Technically speaking the whole 'if ... else' section is not mandatory - simply triggering clearTimeout before every setTimeout would do the trick as well. But since we are already having "self.firepotionTimeout = null" in line 232 i decided to continue with the null handling, the code has more clarity this way.