### PR TITLE
Make AoE deal normal damage to main target

### DIFF
--- a/server/js/player.js
+++ b/server/js/player.js
@@ -198,9 +198,12 @@ module.exports = Player = Character.extend({
                                 let entityIds = Object.keys(group.entities);
                                 entityIds.forEach(function(id) {
                                     let entity = group.entities[id];
-                                    if (entity.type === 'mob') {
+                                    if (entity.type !== undefined && entity.type === 'mob') {
                                         let distance = Utils.distanceTo(self.x, self.y, entity.x, entity.y);
-                                        if (distance === 1) {
+                                        if (mob.id === entity.id) {
+                                            handleDamage(mob, totalLevel, 1);
+                                        }
+                                        else if (distance === 1) {
                                             handleDamage(entity, totalLevel, 0.67);
                                         }
                                     }


### PR DESCRIPTION
- Made a fix to the AoE damage proc to deal normal damage to the main target. Before it was reduced by the AoE multiplier, which made the proc an actual nerf if dealing with only one target.
- Fixed the occasional "TypeError: Cannot read properties of undefined (reading 'type')"