### PR TITLE
Added fix to death from aoe

### DIFF
--- a/server/js/player.js
+++ b/server/js/player.js
@@ -374,13 +374,13 @@ module.exports = Player = Character.extend({
         }
     },
 
-    handleHurt: function(mob) {
+    handleHurt: function(mob, damage) {
         if(mob && this.hitPoints > 0) {
-            let level = this.getLevel();
-
-            let totalLevel = (this.armorLevel + level) - 1;
-           
-            let damage = Formulas.dmg(mob.getWeaponLevel(), totalLevel);
+            if (damage === undefined) {
+                let level = this.getLevel();
+                let totalLevel = (this.armorLevel + level) - 1;
+                damage = Formulas.dmg(mob.getWeaponLevel(), totalLevel);
+            }
             this.hitPoints -= damage;
             this.server.handleHurtEntity(this, mob, damage);
             //console.log(this.name, "Level " + level, "Armor level", this.armorLevel, "Total level", totalLevel, "Hitpoints", this.hitPoints);

--- a/server/js/worldserver.js
+++ b/server/js/worldserver.js
@@ -1009,8 +1009,7 @@ module.exports = World = cls.Class.extend({
                 if (nearbyEntity.type === 'player') {
                     let distance = Utils.distanceTo(mob.x, mob.y, nearbyEntity.x, nearbyEntity.y);
                     if (distance <= aoeRange) {
-                        nearbyEntity.receiveDamage(aoeDmg, mob.id);
-                        self.handleHurtEntity(nearbyEntity, mob, aoeDmg);
+                        nearbyEntity.handleHurt(mob, aoeDmg);
                     }
                 }
             })


### PR DESCRIPTION
I have noticed that currently when a player dies to the AoE damage, theres no discord message + revive isn't working properly.
This commit fixes that. I used handleHurt instead of handleHurtEntity. 
To achieve that I had to make a second parameter that allows to bypass the default damage formula.